### PR TITLE
feat: refactor so that generators only have to implement one, maybe two, functions and never have to deal with file i/o

### DIFF
--- a/lib/generators/custom.ts
+++ b/lib/generators/custom.ts
@@ -1,0 +1,46 @@
+import { Generator, type GenerateInput, type ValidateInput } from "./abstract";
+import { type GeneratorProblemSpec } from "./problem";
+import { GeneratorReportResult } from "./report";
+
+export interface CustomOptions {
+  validate?: (input: ValidateInput, options: CustomOptions, report: (message: GeneratorProblemSpec) => void) => Promise<GeneratorReportResult>;
+  generate?: (input: GenerateInput, options: CustomOptions) => Promise<string>;
+}
+
+export class CustomGenerator extends Generator<CustomOptions> {
+  constructor (options: CustomOptions) {
+    super(options);
+
+    if (!this.options.generate || typeof this.options.generate !== "function") {
+      throw new Error("Must specify a generate function");
+    }
+  }
+
+  async generate (input: GenerateInput) {
+    // non-null assertion safe due to check in the constructor
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return await this.options.generate!(input, this.options);
+  }
+
+  async validate (input: ValidateInput): Promise<GeneratorReportResult> {
+    if (!this.options.validate) {
+      return super.validate(input);
+    }
+
+    let result: GeneratorReportResult;
+    try {
+      // rule disabled, constructor verifies presence of the function
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      result = await this.options.validate(input, this.options, this.report.bind(this));
+    } catch (_err) {
+      const err = _err as Error & { code?: string };
+      this.report({
+        code: err.code,
+        message: err.message,
+      });
+      result = GeneratorReportResult.Fail;
+    }
+
+    return result;
+  }
+}

--- a/lib/generators/index.ts
+++ b/lib/generators/index.ts
@@ -1,16 +1,28 @@
-import type { GeneratorOptions } from "./abstract";
-import { CopyGenerator } from "./copy";
+import { CopyGenerator, type CopyOptions } from "./copy";
+import { CustomGenerator, type CustomOptions } from "./custom";
 import { JsonGenerator, type JsonOptions } from "./json";
 import { PackageGenerator, type PackageOptions } from "./package";
 
-export function copy (sourcePath: string, options: GeneratorOptions = {}) {
-  return new CopyGenerator({ ...options, sourcePath });
+export * from "./abstract";
+export * from "./problem";
+export * from "./report";
+
+export { CopyOptions };
+export function copy (path: string, options?: CopyOptions): CopyGenerator {
+  return new CopyGenerator(options ?? { path });
 }
 
+export { CustomOptions };
+export function custom (options: CustomOptions) {
+  return new CustomGenerator(options);
+}
+
+export { JsonOptions };
 export function json (options: JsonOptions) {
   return new JsonGenerator(options);
 }
 
+export { PackageOptions };
 export function pkg (options: PackageOptions) {
   return new PackageGenerator(options);
 }

--- a/lib/generators/problem.ts
+++ b/lib/generators/problem.ts
@@ -1,0 +1,64 @@
+import { inspect } from "node:util";
+
+export interface GeneratorProblemSpec {
+  code?: string;
+  field?: string;
+  found?: unknown;
+  expected?: unknown;
+  message?: string;
+}
+
+export class GeneratorProblem implements GeneratorProblemSpec {
+  code?: string;
+  field?: string;
+  found?: unknown;
+  expected?: unknown;
+  message?: string;
+
+  constructor (problem: GeneratorProblemSpec) {
+    Object.assign(this, problem);
+  }
+
+  // [$code]: field "$field" $message || "found ${found} but expected ${expected}"
+  toString () {
+    let result = "";
+
+    if (this.code) {
+      result += `[${this.code}]: `;
+    }
+
+    if (this.field) {
+      result += `field "${this.field}" `;
+    }
+
+    if (this.message) {
+      result += this.message;
+    } else {
+      // istanbul ignore else - these are the only combinations we care about
+      if (this.expected && this.found) {
+        result += `expected "${stringify(this.expected)}" but found "${stringify(this.found)}"`;
+      } else if (this.expected) {
+        result += `expected value "${stringify(this.expected)}" to be present`;
+      } else if (this.found) {
+        result += `found unexpected value "${stringify(this.found)}"`;
+      }
+    }
+
+    return result;
+  }
+}
+
+function stringify (input: unknown): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (typeof input === "number" ||
+      typeof input === "boolean" ||
+      typeof input === "bigint" ||
+      typeof input === "symbol") {
+    return input.toString();
+  }
+
+  return inspect(input);
+}

--- a/lib/generators/report.ts
+++ b/lib/generators/report.ts
@@ -1,0 +1,12 @@
+import type { GeneratorProblem } from "./problem";
+
+export enum GeneratorReportResult {
+  Pass = "pass",
+  Fail = "fail",
+}
+
+export interface GeneratorReport {
+  result: GeneratorReportResult;
+  problems: GeneratorProblem[];
+  messages: string[];
+}

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
   "author": "Nathan LaFreniere <nlf@nlf.sh>",
   "license": "ISC",
   "devDependencies": {
-    "@code4rena/skeleton": "1.0.3",
-    "@tsconfig/node18": "^2.0.1",
+    "@code4rena/skeleton": "1.0.5",
+    "@tsconfig/node18": "^18.2.0",
     "@types/color-support": "^1.1.1",
     "@types/node": "^18.16.16",
+    "@types/npmcli__package-json": "^4.0.0",
     "@types/npmcli__promise-spawn": "^6.0.0",
     "@types/tap": "^15.0.8",
     "@types/yargs": "^17.0.24",
@@ -48,9 +49,8 @@
     "ts": true
   },
   "dependencies": {
-    "@npmcli/package-json": "^4.0.1",
+    "@npmcli/package-json": "^5.0.0",
     "@npmcli/promise-spawn": "^6.0.2",
-    "@types/npmcli__package-json": "^2.0.0",
     "ansi-colors": "^4.1.3",
     "color-support": "^1.1.3",
     "json-parse-even-better-errors": "^3.0.0",

--- a/test/custom.ts
+++ b/test/custom.ts
@@ -1,0 +1,241 @@
+import t from "tap";
+
+import {
+  type Config,
+  type CustomOptions,
+  custom,
+  applySkeleton,
+  verifySkeleton,
+  type GenerateInput,
+  type ValidateInput,
+  type GeneratorProblemSpec,
+  GeneratorReportResult,
+} from "../lib";
+
+void t.test("can pass custom methods", async (t) => {
+  const root = t.testdir({});
+
+  const config: Config = {
+    path: root,
+    module: "irrelevant",
+    skeleton: {
+      "foo.txt": custom({
+        generate: (input: GenerateInput): Promise<string> => {
+          const customContent = `generated ${input.path}`;
+          return Promise.resolve(customContent);
+        },
+      }),
+    },
+    variables: {},
+    flags: {
+      silent: true,
+    },
+  };
+
+  const initialVerifyResult = await verifySkeleton(config);
+  t.hasStrict(initialVerifyResult, {
+    exitCode: 1,
+    reports: {
+      "foo.txt": {
+        result: "fail",
+        problems: [{
+          message: "file missing",
+        }],
+      },
+    },
+  });
+
+  const applyResult = await applySkeleton(config);
+  t.hasStrict(applyResult, {
+    exitCode: 0,
+    reports: {},
+  });
+
+  const secondVerifyResult = await verifySkeleton(config);
+  t.hasStrict(secondVerifyResult, {
+    exitCode: 0,
+    reports: {
+      "foo.txt": {
+        result: "pass",
+      },
+    },
+  });
+});
+
+void t.test("can provide custom validate function", async (t) => {
+  const root = t.testdir({});
+
+  const config: Config = {
+    path: root,
+    module: "irrelevant",
+    skeleton: {
+      "foo.txt": custom({
+        generate: (input: GenerateInput): Promise<string> => {
+          const customContent = `generated ${input.path}`;
+          return Promise.resolve(customContent);
+        },
+        validate: (input: ValidateInput): Promise<GeneratorReportResult> => {
+          t.equal(input.found, `generated ${input.path}`);
+          return Promise.resolve(GeneratorReportResult.Pass);
+        },
+      }),
+    },
+    variables: {},
+    flags: {
+      silent: true,
+    },
+  };
+
+  const initialVerifyResult = await verifySkeleton(config);
+  t.hasStrict(initialVerifyResult, {
+    exitCode: 1,
+    reports: {
+      "foo.txt": {
+        result: "fail",
+        problems: [{
+          message: "file missing",
+        }],
+      },
+    },
+  });
+
+  const applyResult = await applySkeleton(config);
+  t.hasStrict(applyResult, {
+    exitCode: 0,
+    reports: {},
+  });
+
+  const secondVerifyResult = await verifySkeleton(config);
+  t.hasStrict(secondVerifyResult, {
+    exitCode: 0,
+    reports: {
+      "foo.txt": {
+        result: "pass",
+      },
+    },
+  });
+});
+
+void t.test("can report errors from custom validate function", async (t) => {
+  const root = t.testdir({});
+
+  const config: Config = {
+    path: root,
+    module: "irrelevant",
+    skeleton: {
+      "foo.txt": custom({
+        generate: (input: GenerateInput): Promise<string> => {
+          const customContent = `generated ${input.path}`;
+          return Promise.resolve(customContent);
+        },
+        validate: (input: ValidateInput, options: CustomOptions, report: (message: GeneratorProblemSpec) => void): Promise<GeneratorReportResult> => {
+          report({
+            message: "custom validate says no",
+          });
+          return Promise.resolve(GeneratorReportResult.Fail);
+        },
+      }),
+    },
+    variables: {},
+    flags: {
+      silent: true,
+    },
+  };
+
+  const initialVerifyResult = await verifySkeleton(config);
+  t.hasStrict(initialVerifyResult, {
+    exitCode: 1,
+    reports: {
+      "foo.txt": {
+        result: "fail",
+        problems: [{
+          message: "file missing",
+        }],
+      },
+    },
+  });
+
+  const applyResult = await applySkeleton(config);
+  t.hasStrict(applyResult, {
+    exitCode: 0,
+    reports: {},
+  });
+
+  const secondVerifyResult = await verifySkeleton(config);
+  t.hasStrict(secondVerifyResult, {
+    exitCode: 1,
+    reports: {
+      "foo.txt": {
+        result: "fail",
+        problems: [{
+          message: "custom validate says no",
+        }],
+      },
+    },
+  });
+});
+
+void t.test("thrown errors from custom validate cause failure", async (t) => {
+  const root = t.testdir({});
+
+  const config: Config = {
+    path: root,
+    module: "irrelevant",
+    skeleton: {
+      "foo.txt": custom({
+        generate: (input: GenerateInput): Promise<string> => {
+          const customContent = `generated ${input.path}`;
+          return Promise.resolve(customContent);
+        },
+        validate: (): Promise<GeneratorReportResult> => {
+          throw Object.assign(new Error("kaboom"), { code: "EBOOM" });
+        },
+      }),
+    },
+    variables: {},
+    flags: {
+      silent: true,
+    },
+  };
+
+  const initialVerifyResult = await verifySkeleton(config);
+  t.hasStrict(initialVerifyResult, {
+    exitCode: 1,
+    reports: {
+      "foo.txt": {
+        result: "fail",
+        problems: [{
+          message: "file missing",
+        }],
+      },
+    },
+  });
+
+  const applyResult = await applySkeleton(config);
+  t.hasStrict(applyResult, {
+    exitCode: 0,
+    reports: {},
+  });
+
+  const secondVerifyResult = await verifySkeleton(config);
+  t.hasStrict(secondVerifyResult, {
+    exitCode: 1,
+    reports: {
+      "foo.txt": {
+        result: "fail",
+        problems: [{
+          code: "EBOOM",
+          message: "kaboom",
+        }],
+      },
+    },
+  });
+});
+
+void t.test("throws for missing options", (t) => {
+  t.throws(() => custom({}), {
+    message: "Must specify a generate function",
+  });
+
+  t.end();
+});


### PR DESCRIPTION
BREAKING CHANGE: external generators must be rewritten to match the new interface

as part of this i also reimplemented the package.json generator so that it correctly supports non-standard top level keys